### PR TITLE
update site with fixed links and images

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,22 +1,11 @@
 title: Mixed-Precision Multigrid Solvers for PDEs
-description: High-performance multigrid + mixed-precision methods on CPU/GPU for elliptic PDEs.
-theme: minima
-
 url: "https://tani843.github.io"
-baseurl: "/Mixed_Precision_Multigrid_Solvers_for_PDEs"  # IMPORTANT
+baseurl: "/Mixed_Precision_Multigrid_Solvers_for_PDEs"
 
-markdown: kramdown
 plugins:
   - jekyll-relative-links
   - jekyll-seo-tag
 
-relative_links:
-  enabled: true
-  collections: true
-
-# Ensure assets paths are stable
 defaults:
-  - scope:
-      path: ""
-    values:
-      layout: default
+  - scope: { path: "" }
+    values: { layout: default }

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,0 +1,15 @@
+primary:
+  - { label: "Home",         url: "/" }
+  - { label: "Methodology",  url: "/methodology/" }
+  - { label: "Results",      url: "/results/" }
+  - { label: "Contact",      url: "/contact/" }
+more:
+  - { label: "About",                         url: "/about/" }
+  - { label: "Conclusion",                    url: "/conclusion/" }
+  - { label: "Advanced Visualization",        url: "/advanced_visualization/" }
+  - { label: "Tools",                         url: "/tools/" }
+  - { label: "Installation Guide",            url: "/installation/" }
+  - { label: "Performance Optimization Report", url: "/performance_optimization/" }
+  - { label: "Real-time Solver Monitoring",   url: "/realtime_dashboard/" }
+  - { label: "Dashboard",                     url: "/dashboard/" }
+  - { label: "Troubleshooting Guide",         url: "/troubleshooting/" }

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,0 +1,61 @@
+<nav class="topnav">
+  <div class="topnav__inner">
+    <a class="brand" href="{{ '/' | relative_url }}">
+      {{ site.title }}
+    </a>
+
+    <button class="burger" aria-label="Toggle menu" onclick="document.body.classList.toggle('nav-open')">☰</button>
+
+    <ul class="menu">
+      {%- for item in site.data.nav.primary -%}
+        <li><a href="{{ item.url | relative_url }}">{{ item.label }}</a></li>
+      {%- endfor -%}
+
+      <li class="dropdown">
+        <button class="dropbtn" aria-haspopup="true" aria-expanded="false">More ▾</button>
+        <ul class="dropdown-content">
+          {%- for item in site.data.nav.more -%}
+            <li><a href="{{ item.url | relative_url }}">{{ item.label }}</a></li>
+          {%- endfor -%}
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+<style>
+/* Layout */
+.topnav { border-bottom: 1px solid #e5e5e5; }
+.topnav__inner { max-width: 980px; margin: 0 auto; padding: 10px 16px; display: flex; align-items: center; gap: 16px; }
+.brand { font-weight: 600; text-decoration: none; color: inherit; white-space: nowrap; }
+
+/* Menu */
+.menu { margin-left: auto; display: flex; align-items: center; gap: 16px; list-style: none; padding: 0; }
+.menu > li > a { text-decoration: none; color: inherit; }
+.menu > li > a:hover { text-decoration: underline; }
+/* Dropdown */
+.dropdown { position: relative; }
+.dropbtn { background: transparent; border: none; cursor: pointer; font: inherit; }
+.dropdown-content {
+  position: absolute; right: 0; top: 100%;
+  background: #fff; border: 1px solid #e5e5e5; border-radius: 6px;
+  padding: 6px 0; list-style: none; margin: 8px 0 0 0; min-width: 260px;
+  display: none; z-index: 10;
+}
+.dropdown-content li a { display: block; padding: 8px 12px; text-decoration: none; color: inherit; }
+.dropdown-content li a:hover { background: #f6f6f6; }
+.dropdown:hover .dropdown-content { display: block; }
+/* Burger (mobile) */
+.burger { display: none; margin-left: auto; font-size: 20px; background: transparent; border: 1px solid #ddd; padding: 4px 8px; border-radius: 6px; cursor: pointer; }
+
+/* Mobile styles */
+@media (max-width: 760px) {
+  .burger { display: inline-block; }
+  .menu { display: none; position: absolute; left: 0; right: 0; top: 56px; background: #fff; border-bottom: 1px solid #e5e5e5; padding: 10px 16px; flex-direction: column; gap: 10px; }
+  body.nav-open .menu { display: flex; }
+  .dropdown { position: static; }
+  .dropdown-content { position: static; border: none; padding: 0; display: block; box-shadow: none; }
+  .dropbtn { text-align: left; padding: 0; }
+}
+/* Add breathing room between nav and page title */
+.page-header-spacer { height: 16px; }
+</style>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% if page.title %}{{ page.title | escape }} – {% endif %}{{ site.title | escape }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <style>
+    body { max-width: 980px; margin: 0 auto; padding: 0 16px 40px; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans"; }
+    .title-wrap { text-align: left; margin: 18px 0 0; }
+    .subtitle { color: #666; font-style: italic; margin-top: 6px; }
+  </style>
+</head>
+<body>
+ {% include nav.html %}
+  <div class="page-header-spacer"></div>
+
+  <header class="title-wrap">
+    {% if page.title %}
+      <h1>{{ page.title }}</h1>
+    {% endif %}
+    {% if page.subtitle %}
+      <div class="subtitle">{{ page.subtitle }}</div>
+    {% endif %}
+  </header>
+
+  <main>
+    {{ content }}
+  </main>
+</body>
+</html>


### PR DESCRIPTION
This PR updates the GitHub Pages Jekyll site with a cleaner navigation bar, fixed links, and properly organized assets.

Changes
	•	Added docs/_data/nav.yml for ordered navigation structure.
	•	Added docs/_includes/nav.html with dropdown support for extra links.
	•	Updated docs/_layouts/default.html to include clean top navigation.
	•	Normalized paths for images and documentation pages.

Validation
	• Navigation links render in correct order.
	• Dropdown works for extra items (Tools, Dashboard, etc.).
	• Images load correctly from /assets/images/.
	• All relative URLs tested successfully.

